### PR TITLE
Changed deprecated as_matrix() to to_numpy()

### DIFF
--- a/calib_eq_odds.py
+++ b/calib_eq_odds.py
@@ -201,10 +201,10 @@ if __name__ == '__main__':
     group_0_test_data = test_data[test_data['group'] == 0]
     group_1_test_data = test_data[test_data['group'] == 1]
 
-    group_0_val_model = Model(group_0_val_data['prediction'].as_matrix(), group_0_val_data['label'].as_matrix())
-    group_1_val_model = Model(group_1_val_data['prediction'].as_matrix(), group_1_val_data['label'].as_matrix())
-    group_0_test_model = Model(group_0_test_data['prediction'].as_matrix(), group_0_test_data['label'].as_matrix())
-    group_1_test_model = Model(group_1_test_data['prediction'].as_matrix(), group_1_test_data['label'].as_matrix())
+    group_0_val_model = Model(group_0_val_data['prediction'].to_numpy(), group_0_val_data['label'].to_numpy())
+    group_1_val_model = Model(group_1_val_data['prediction'].to_numpy(), group_1_val_data['label'].to_numpy())
+    group_0_test_model = Model(group_0_test_data['prediction'].to_numpy(), group_0_test_data['label'].to_numpy())
+    group_1_test_model = Model(group_1_test_data['prediction'].to_numpy(), group_1_test_data['label'].to_numpy())
 
     # Find mixing rates for equalized odds models
     _, _, mix_rates = Model.calib_eq_odds(group_0_val_model, group_1_val_model, fp_rate, fn_rate)

--- a/eq_odds.py
+++ b/eq_odds.py
@@ -228,10 +228,10 @@ if __name__ == '__main__':
     group_0_test_data = test_data[test_data['group'] == 0]
     group_1_test_data = test_data[test_data['group'] == 1]
 
-    group_0_val_model = Model(group_0_val_data['prediction'].as_matrix(), group_0_val_data['label'].as_matrix())
-    group_1_val_model = Model(group_1_val_data['prediction'].as_matrix(), group_1_val_data['label'].as_matrix())
-    group_0_test_model = Model(group_0_test_data['prediction'].as_matrix(), group_0_test_data['label'].as_matrix())
-    group_1_test_model = Model(group_1_test_data['prediction'].as_matrix(), group_1_test_data['label'].as_matrix())
+    group_0_val_model = Model(group_0_val_data['prediction'].to_numpy(), group_0_val_data['label'].to_numpy())
+    group_1_val_model = Model(group_1_val_data['prediction'].to_numpy(), group_1_val_data['label'].to_numpy())
+    group_0_test_model = Model(group_0_test_data['prediction'].to_numpy(), group_0_test_data['label'].to_numpy())
+    group_1_test_model = Model(group_1_test_data['prediction'].to_numpy(), group_1_test_data['label'].to_numpy())
 
     # Find mixing rates for equalized odds models
     _, _, mix_rates = Model.eq_odds(group_0_val_model, group_1_val_model)


### PR DESCRIPTION
- Fixed AttributeError: 'Series' object has no attribute 'as_matrix'
- as_matrix() is [deprecated since pandas version 0.23.0](https://pandas.pydata.org/pandas-docs/version/0.25.1/reference/api/pandas.DataFrame.as_matrix.html)
- Used to_numpy() instead